### PR TITLE
Add external icon to card headers, remove from buttons

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -232,7 +232,12 @@ export default function Home() {
                 selectionGroupLabel: 'Demo selection',
               }}
               cardDefinition={{
-                header: item => <Link href={item.route}>{item.title}</Link>,
+                header: item => (
+                  <Link href={item.route}>
+                    {item.title}
+                    <Icon name="external" />
+                  </Link>
+                ),
                 sections: [
                   {
                     id: 'description',
@@ -242,7 +247,7 @@ export default function Home() {
                   {
                     id: 'actions',
                     content: item => (
-                      <Button href={item.route} iconAlign="right" iconName="external" variant="primary">
+                      <Button href={item.route} variant="primary">
                         Open demo
                       </Button>
                     ),

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -235,7 +235,9 @@ export default function Home() {
                 header: item => (
                   <Link href={item.route}>
                     {item.title}
-                    <Icon name="external" />
+                    <span style={{ color: 'pink' }}>
+                      <Icon name="external" />
+                    </span>
                   </Link>
                 ),
                 sections: [


### PR DESCRIPTION
## Purpose
Based on the conversation context referencing visual changes to the index page, this update improves the visual consistency of card components by repositioning external link indicators.

## Code changes
- **Card headers**: Added external icon next to the title link in card headers to clearly indicate external navigation
- **Action buttons**: Removed the external icon and right alignment from the "Open demo" buttons to simplify the button design
- **Component structure**: Refactored the header from inline JSX to a multi-line component structure for better readability

The changes maintain the same functionality while improving the visual hierarchy by moving the external link indicator to the card header where it's more prominent and contextually appropriate.

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 2`

🔗 [Edit in Builder.io](https://builder.io/app/projects/11ede865f9e143959d57f7f316bbd306/nova-space)

👀 [Preview Link](https://11ede865f9e143959d57f7f316bbd306-nova-space.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>11ede865f9e143959d57f7f316bbd306</projectId>-->
<!--<branchName>nova-space</branchName>-->