### PR TITLE
Add weather dashboard with Fahrenheit and scrollable forecast

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -128,6 +128,7 @@ const demos = [
   },
   { route: '/wizard', title: 'Wizard', description: 'Multi-step wizard demo.', category: 'Forms' },
   { route: '/write-to-s3', title: 'Write to S3', description: 'Write data to Amazon S3.', category: 'Integration' },
+  { route: '/weather-dashboard', title: 'Weather Dashboard', description: 'Real-time weather data and forecasts using Open-Meteo API.', category: 'Dashboards' },
 ];
 
 // Get unique categories

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -128,7 +128,12 @@ const demos = [
   },
   { route: '/wizard', title: 'Wizard', description: 'Multi-step wizard demo.', category: 'Forms' },
   { route: '/write-to-s3', title: 'Write to S3', description: 'Write data to Amazon S3.', category: 'Integration' },
-  { route: '/weather-dashboard', title: 'Weather Dashboard', description: 'Real-time weather data and forecasts using Open-Meteo API.', category: 'Dashboards' },
+  {
+    route: '/weather-dashboard',
+    title: 'Weather Dashboard',
+    description: 'Real-time weather data and forecasts using Open-Meteo API.',
+    category: 'Dashboards',
+  },
 ];
 
 // Get unique categories

--- a/src/pages/weather-dashboard/index.tsx
+++ b/src/pages/weather-dashboard/index.tsx
@@ -1,0 +1,369 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+import React, { useState, useEffect } from 'react';
+import AppLayout from '@cloudscape-design/components/app-layout';
+import ContentLayout from '@cloudscape-design/components/content-layout';
+import Header from '@cloudscape-design/components/header';
+import Container from '@cloudscape-design/components/container';
+import SpaceBetween from '@cloudscape-design/components/space-between';
+import Grid from '@cloudscape-design/components/grid';
+import Box from '@cloudscape-design/components/box';
+import Badge from '@cloudscape-design/components/badge';
+import StatusIndicator from '@cloudscape-design/components/status-indicator';
+import Button from '@cloudscape-design/components/button';
+import Input from '@cloudscape-design/components/input';
+import FormField from '@cloudscape-design/components/form-field';
+import ColumnLayout from '@cloudscape-design/components/column-layout';
+import LineChart from '@cloudscape-design/components/line-chart';
+import BarChart from '@cloudscape-design/components/bar-chart';
+import Spinner from '@cloudscape-design/components/spinner';
+import Alert from '@cloudscape-design/components/alert';
+
+interface WeatherData {
+  current: {
+    temperature_2m: number;
+    relative_humidity_2m: number;
+    apparent_temperature: number;
+    precipitation: number;
+    wind_speed_10m: number;
+    wind_direction_10m: number;
+    weather_code: number;
+  };
+  hourly: {
+    time: string[];
+    temperature_2m: number[];
+    precipitation: number[];
+    wind_speed_10m: number[];
+  };
+  daily: {
+    time: string[];
+    temperature_2m_max: number[];
+    temperature_2m_min: number[];
+    precipitation_sum: number[];
+    weather_code: number[];
+  };
+}
+
+interface LocationData {
+  name: string;
+  latitude: number;
+  longitude: number;
+}
+
+const weatherCodeMap: { [key: number]: { label: string; severity: 'success' | 'warning' | 'error' } } = {
+  0: { label: 'Clear sky', severity: 'success' },
+  1: { label: 'Mainly clear', severity: 'success' },
+  2: { label: 'Partly cloudy', severity: 'success' },
+  3: { label: 'Overcast', severity: 'warning' },
+  45: { label: 'Fog', severity: 'warning' },
+  48: { label: 'Depositing rime fog', severity: 'warning' },
+  51: { label: 'Light drizzle', severity: 'warning' },
+  53: { label: 'Moderate drizzle', severity: 'warning' },
+  55: { label: 'Dense drizzle', severity: 'warning' },
+  61: { label: 'Slight rain', severity: 'warning' },
+  63: { label: 'Moderate rain', severity: 'error' },
+  65: { label: 'Heavy rain', severity: 'error' },
+  71: { label: 'Slight snow', severity: 'warning' },
+  73: { label: 'Moderate snow', severity: 'error' },
+  75: { label: 'Heavy snow', severity: 'error' },
+  95: { label: 'Thunderstorm', severity: 'error' },
+};
+
+export default function WeatherDashboard() {
+  const [weatherData, setWeatherData] = useState<WeatherData | null>(null);
+  const [location, setLocation] = useState<LocationData>({ name: 'New York', latitude: 40.7128, longitude: -74.0060 });
+  const [searchLocation, setSearchLocation] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchWeatherData = async (lat: number, lon: number) => {
+    setLoading(true);
+    setError(null);
+    try {
+      const response = await fetch(
+        `https://api.open-meteo.com/v1/forecast?latitude=${lat}&longitude=${lon}&current=temperature_2m,relative_humidity_2m,apparent_temperature,precipitation,wind_speed_10m,wind_direction_10m,weather_code&hourly=temperature_2m,precipitation,wind_speed_10m&daily=temperature_2m_max,temperature_2m_min,precipitation_sum,weather_code&temperature_unit=celsius&wind_speed_unit=kmh&precipitation_unit=mm&timezone=auto&forecast_days=7`
+      );
+      
+      if (!response.ok) {
+        throw new Error('Failed to fetch weather data');
+      }
+      
+      const data = await response.json();
+      setWeatherData(data);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'An error occurred');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const searchLocationByName = async (locationName: string) => {
+    if (!locationName.trim()) return;
+    
+    setLoading(true);
+    setError(null);
+    try {
+      const response = await fetch(
+        `https://geocoding-api.open-meteo.com/v1/search?name=${encodeURIComponent(locationName)}&count=1`
+      );
+      
+      if (!response.ok) {
+        throw new Error('Failed to search location');
+      }
+      
+      const data = await response.json();
+      if (data.results && data.results.length > 0) {
+        const result = data.results[0];
+        const newLocation = {
+          name: result.name + (result.country ? `, ${result.country}` : ''),
+          latitude: result.latitude,
+          longitude: result.longitude,
+        };
+        setLocation(newLocation);
+        await fetchWeatherData(result.latitude, result.longitude);
+      } else {
+        throw new Error('Location not found');
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to search location');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchWeatherData(location.latitude, location.longitude);
+  }, []);
+
+  const formatTemperature = (temp: number) => `${Math.round(temp)}°C`;
+  const formatWindDirection = (degrees: number) => {
+    const directions = ['N', 'NE', 'E', 'SE', 'S', 'SW', 'W', 'NW'];
+    return directions[Math.round(degrees / 45) % 8];
+  };
+
+  const prepareHourlyChartData = () => {
+    if (!weatherData?.hourly) return [];
+    
+    return weatherData.hourly.time.slice(0, 24).map((time, index) => ({
+      x: new Date(time).getHours(),
+      y: weatherData.hourly.temperature_2m[index],
+    }));
+  };
+
+  const prepareDailyChartData = () => {
+    if (!weatherData?.daily) return [];
+    
+    return weatherData.daily.time.map((time, index) => ({
+      x: new Date(time).toLocaleDateString('en-US', { weekday: 'short' }),
+      max: weatherData.daily.temperature_2m_max[index],
+      min: weatherData.daily.temperature_2m_min[index],
+      precipitation: weatherData.daily.precipitation_sum[index],
+    }));
+  };
+
+  const currentWeather = weatherData?.current;
+  const weatherCondition = currentWeather?.weather_code 
+    ? weatherCodeMap[currentWeather.weather_code] || { label: 'Unknown', severity: 'warning' as const }
+    : { label: 'Loading...', severity: 'warning' as const };
+
+  return (
+    <AppLayout
+      navigationHide
+      toolsHide
+      content={
+        <ContentLayout
+          header={
+            <Header
+              variant="h1"
+              actions={
+                <Button
+                  variant="primary"
+                  iconName="refresh"
+                  onClick={() => fetchWeatherData(location.latitude, location.longitude)}
+                  loading={loading}
+                >
+                  Refresh
+                </Button>
+              }
+            >
+              Weather Dashboard
+            </Header>
+          }
+        >
+          <SpaceBetween size="l">
+            {error && (
+              <Alert type="error" dismissible onDismiss={() => setError(null)}>
+                {error}
+              </Alert>
+            )}
+
+            <Container>
+              <SpaceBetween size="m">
+                <Box variant="h2">Location Search</Box>
+                <ColumnLayout columns={2}>
+                  <FormField label="Search location">
+                    <Input
+                      value={searchLocation}
+                      onChange={({ detail }) => setSearchLocation(detail.value)}
+                      placeholder="Enter city name..."
+                      onKeyDown={(e) => {
+                        if (e.detail.key === 'Enter') {
+                          searchLocationByName(searchLocation);
+                        }
+                      }}
+                    />
+                  </FormField>
+                  <FormField label=" ">
+                    <Button
+                      variant="primary"
+                      onClick={() => searchLocationByName(searchLocation)}
+                      loading={loading}
+                    >
+                      Search
+                    </Button>
+                  </FormField>
+                </ColumnLayout>
+              </SpaceBetween>
+            </Container>
+
+            <Container>
+              <SpaceBetween size="m">
+                <Box variant="h2">Current Weather - {location.name}</Box>
+                {loading && !weatherData ? (
+                  <Box textAlign="center">
+                    <Spinner size="large" />
+                  </Box>
+                ) : currentWeather ? (
+                  <ColumnLayout columns={4}>
+                    <Box>
+                      <Box variant="h3">Temperature</Box>
+                      <Box fontSize="display-l" fontWeight="bold">
+                        {formatTemperature(currentWeather.temperature_2m)}
+                      </Box>
+                      <Box variant="small">
+                        Feels like {formatTemperature(currentWeather.apparent_temperature)}
+                      </Box>
+                    </Box>
+                    <Box>
+                      <Box variant="h3">Conditions</Box>
+                      <StatusIndicator type={weatherCondition.severity}>
+                        {weatherCondition.label}
+                      </StatusIndicator>
+                    </Box>
+                    <Box>
+                      <Box variant="h3">Humidity</Box>
+                      <Box variant="p">{currentWeather.relative_humidity_2m}%</Box>
+                    </Box>
+                    <Box>
+                      <Box variant="h3">Wind</Box>
+                      <Box variant="p">
+                        {currentWeather.wind_speed_10m} km/h {formatWindDirection(currentWeather.wind_direction_10m)}
+                      </Box>
+                    </Box>
+                  </ColumnLayout>
+                ) : null}
+              </SpaceBetween>
+            </Container>
+
+            <Grid gridDefinition={[{ colspan: 6 }, { colspan: 6 }]}>
+              <Container>
+                <SpaceBetween size="m">
+                  <Box variant="h2">24-Hour Temperature Trend</Box>
+                  {weatherData?.hourly ? (
+                    <LineChart
+                      series={[
+                        {
+                          title: 'Temperature (°C)',
+                          type: 'line',
+                          data: prepareHourlyChartData(),
+                        },
+                      ]}
+                      xDomain={[0, 23]}
+                      yTitle="Temperature (°C)"
+                      xTitle="Hour"
+                      height={300}
+                      hideFilter
+                    />
+                  ) : (
+                    <Box textAlign="center">
+                      <Spinner />
+                    </Box>
+                  )}
+                </SpaceBetween>
+              </Container>
+
+              <Container>
+                <SpaceBetween size="m">
+                  <Box variant="h2">7-Day Forecast</Box>
+                  {weatherData?.daily ? (
+                    <BarChart
+                      series={[
+                        {
+                          title: 'Max Temp (°C)',
+                          type: 'bar',
+                          data: prepareDailyChartData().map(d => ({ x: d.x, y: d.max })),
+                        },
+                        {
+                          title: 'Min Temp (°C)',
+                          type: 'bar',
+                          data: prepareDailyChartData().map(d => ({ x: d.x, y: d.min })),
+                        },
+                      ]}
+                      yTitle="Temperature (°C)"
+                      xTitle="Day"
+                      height={300}
+                      hideFilter
+                    />
+                  ) : (
+                    <Box textAlign="center">
+                      <Spinner />
+                    </Box>
+                  )}
+                </SpaceBetween>
+              </Container>
+            </Grid>
+
+            <Container>
+              <SpaceBetween size="m">
+                <Box variant="h2">Weekly Overview</Box>
+                {weatherData?.daily ? (
+                  <ColumnLayout columns={7}>
+                    {weatherData.daily.time.map((day, index) => {
+                      const dayWeather = weatherCodeMap[weatherData.daily.weather_code[index]] || { label: 'Unknown', severity: 'warning' as const };
+                      return (
+                        <Box key={day} textAlign="center">
+                          <Box variant="small" fontWeight="bold">
+                            {new Date(day).toLocaleDateString('en-US', { weekday: 'short' })}
+                          </Box>
+                          <Box margin={{ top: 'xs', bottom: 'xs' }}>
+                            <Badge color={dayWeather.severity === 'success' ? 'green' : dayWeather.severity === 'warning' ? 'blue' : 'red'}>
+                              {dayWeather.label}
+                            </Badge>
+                          </Box>
+                          <Box variant="small">
+                            <strong>{formatTemperature(weatherData.daily.temperature_2m_max[index])}</strong>
+                          </Box>
+                          <Box variant="small" color="text-status-inactive">
+                            {formatTemperature(weatherData.daily.temperature_2m_min[index])}
+                          </Box>
+                          <Box variant="small">
+                            {weatherData.daily.precipitation_sum[index].toFixed(1)}mm
+                          </Box>
+                        </Box>
+                      );
+                    })}
+                  </ColumnLayout>
+                ) : (
+                  <Box textAlign="center">
+                    <Spinner />
+                  </Box>
+                )}
+              </SpaceBetween>
+            </Container>
+          </SpaceBetween>
+        </ContentLayout>
+      }
+    />
+  );
+}

--- a/src/pages/weather-dashboard/index.tsx
+++ b/src/pages/weather-dashboard/index.tsx
@@ -73,7 +73,7 @@ const weatherCodeMap: { [key: number]: { label: string; severity: 'success' | 'w
 
 export default function WeatherDashboard() {
   const [weatherData, setWeatherData] = useState<WeatherData | null>(null);
-  const [location, setLocation] = useState<LocationData>({ name: 'New York', latitude: 40.7128, longitude: -74.0060 });
+  const [location, setLocation] = useState<LocationData>({ name: 'New York', latitude: 40.7128, longitude: -74.006 });
   const [searchLocation, setSearchLocation] = useState('');
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -83,13 +83,13 @@ export default function WeatherDashboard() {
     setError(null);
     try {
       const response = await fetch(
-        `/api/weather/v1/forecast?latitude=${lat}&longitude=${lon}&current=temperature_2m,relative_humidity_2m,apparent_temperature,precipitation,wind_speed_10m,wind_direction_10m,weather_code&hourly=temperature_2m,precipitation,wind_speed_10m&daily=temperature_2m_max,temperature_2m_min,precipitation_sum,weather_code&temperature_unit=fahrenheit&wind_speed_unit=kmh&precipitation_unit=mm&timezone=auto&forecast_days=7`
+        `/api/weather/v1/forecast?latitude=${lat}&longitude=${lon}&current=temperature_2m,relative_humidity_2m,apparent_temperature,precipitation,wind_speed_10m,wind_direction_10m,weather_code&hourly=temperature_2m,precipitation,wind_speed_10m&daily=temperature_2m_max,temperature_2m_min,precipitation_sum,weather_code&temperature_unit=fahrenheit&wind_speed_unit=kmh&precipitation_unit=mm&timezone=auto&forecast_days=7`,
       );
-      
+
       if (!response.ok) {
         throw new Error('Failed to fetch weather data');
       }
-      
+
       const data = await response.json();
       setWeatherData(data);
     } catch (err) {
@@ -101,18 +101,16 @@ export default function WeatherDashboard() {
 
   const searchLocationByName = async (locationName: string) => {
     if (!locationName.trim()) return;
-    
+
     setLoading(true);
     setError(null);
     try {
-      const response = await fetch(
-        `/api/geocoding/v1/search?name=${encodeURIComponent(locationName)}&count=1`
-      );
-      
+      const response = await fetch(`/api/geocoding/v1/search?name=${encodeURIComponent(locationName)}&count=1`);
+
       if (!response.ok) {
         throw new Error('Failed to search location');
       }
-      
+
       const data = await response.json();
       if (data.results && data.results.length > 0) {
         const result = data.results[0];
@@ -145,7 +143,7 @@ export default function WeatherDashboard() {
 
   const prepareHourlyChartData = () => {
     if (!weatherData?.hourly) return [];
-    
+
     return weatherData.hourly.time.slice(0, 24).map((time, index) => ({
       x: new Date(time).getHours(),
       y: weatherData.hourly.temperature_2m[index],
@@ -154,7 +152,7 @@ export default function WeatherDashboard() {
 
   const prepareDailyChartData = () => {
     if (!weatherData?.daily) return [];
-    
+
     return weatherData.daily.time.map((time, index) => ({
       x: new Date(time).toLocaleDateString('en-US', { weekday: 'short' }),
       max: weatherData.daily.temperature_2m_max[index],
@@ -208,7 +206,7 @@ export default function WeatherDashboard() {
                       value={searchLocation}
                       onChange={({ detail }) => setSearchLocation(detail.value)}
                       placeholder="Enter city name..."
-                      onKeyDown={(e) => {
+                      onKeyDown={e => {
                         if (e.detail.key === 'Enter') {
                           searchLocationByName(searchLocation);
                         }
@@ -216,11 +214,7 @@ export default function WeatherDashboard() {
                     />
                   </FormField>
                   <FormField label=" ">
-                    <Button
-                      variant="primary"
-                      onClick={() => searchLocationByName(searchLocation)}
-                      loading={loading}
-                    >
+                    <Button variant="primary" onClick={() => searchLocationByName(searchLocation)} loading={loading}>
                       Search
                     </Button>
                   </FormField>
@@ -242,15 +236,11 @@ export default function WeatherDashboard() {
                       <Box fontSize="display-l" fontWeight="bold">
                         {formatTemperature(currentWeather.temperature_2m)}
                       </Box>
-                      <Box variant="small">
-                        Feels like {formatTemperature(currentWeather.apparent_temperature)}
-                      </Box>
+                      <Box variant="small">Feels like {formatTemperature(currentWeather.apparent_temperature)}</Box>
                     </Box>
                     <Box>
                       <Box variant="h3">Conditions</Box>
-                      <StatusIndicator type={weatherCondition.severity}>
-                        {weatherCondition.label}
-                      </StatusIndicator>
+                      <StatusIndicator type={weatherCondition.severity}>{weatherCondition.label}</StatusIndicator>
                     </Box>
                     <Box>
                       <Box variant="h3">Humidity</Box>
@@ -334,19 +324,15 @@ export default function WeatherDashboard() {
                       const dayWeather = weatherCodeMap[weatherData.daily.weather_code[index]] || {
                         label: 'Unknown',
                         severity: 'warning' as const,
-                        icon: '❓'
+                        icon: '❓',
                       };
                       return (
                         <div key={day} className={styles.forecastCard}>
                           <div className={styles.dayName}>
                             {new Date(day).toLocaleDateString('en-US', { weekday: 'short' })}
                           </div>
-                          <span className={styles.weatherIcon}>
-                            {dayWeather.icon}
-                          </span>
-                          <div className={styles.conditionLabel}>
-                            {dayWeather.label}
-                          </div>
+                          <span className={styles.weatherIcon}>{dayWeather.icon}</span>
+                          <div className={styles.conditionLabel}>{dayWeather.label}</div>
                           <div className={styles.tempHigh}>
                             {formatTemperature(weatherData.daily.temperature_2m_max[index])}
                           </div>

--- a/src/pages/weather-dashboard/index.tsx
+++ b/src/pages/weather-dashboard/index.tsx
@@ -300,17 +300,17 @@ export default function WeatherDashboard() {
                     <BarChart
                       series={[
                         {
-                          title: 'Max Temp (°C)',
+                          title: 'Max Temp (°F)',
                           type: 'bar',
                           data: prepareDailyChartData().map(d => ({ x: d.x, y: d.max })),
                         },
                         {
-                          title: 'Min Temp (°C)',
+                          title: 'Min Temp (°F)',
                           type: 'bar',
                           data: prepareDailyChartData().map(d => ({ x: d.x, y: d.min })),
                         },
                       ]}
-                      yTitle="Temperature (°C)"
+                      yTitle="Temperature (°F)"
                       xTitle="Day"
                       height={300}
                       hideFilter

--- a/src/pages/weather-dashboard/index.tsx
+++ b/src/pages/weather-dashboard/index.tsx
@@ -105,7 +105,7 @@ export default function WeatherDashboard() {
     setError(null);
     try {
       const response = await fetch(
-        `https://geocoding-api.open-meteo.com/v1/search?name=${encodeURIComponent(locationName)}&count=1`
+        `/api/geocoding/v1/search?name=${encodeURIComponent(locationName)}&count=1`
       );
       
       if (!response.ok) {

--- a/src/pages/weather-dashboard/index.tsx
+++ b/src/pages/weather-dashboard/index.tsx
@@ -82,7 +82,7 @@ export default function WeatherDashboard() {
     setError(null);
     try {
       const response = await fetch(
-        `https://api.open-meteo.com/v1/forecast?latitude=${lat}&longitude=${lon}&current=temperature_2m,relative_humidity_2m,apparent_temperature,precipitation,wind_speed_10m,wind_direction_10m,weather_code&hourly=temperature_2m,precipitation,wind_speed_10m&daily=temperature_2m_max,temperature_2m_min,precipitation_sum,weather_code&temperature_unit=fahrenheit&wind_speed_unit=kmh&precipitation_unit=mm&timezone=auto&forecast_days=7`
+        `/api/weather/v1/forecast?latitude=${lat}&longitude=${lon}&current=temperature_2m,relative_humidity_2m,apparent_temperature,precipitation,wind_speed_10m,wind_direction_10m,weather_code&hourly=temperature_2m,precipitation,wind_speed_10m&daily=temperature_2m_max,temperature_2m_min,precipitation_sum,weather_code&temperature_unit=fahrenheit&wind_speed_unit=kmh&precipitation_unit=mm&timezone=auto&forecast_days=7`
       );
       
       if (!response.ok) {

--- a/src/pages/weather-dashboard/index.tsx
+++ b/src/pages/weather-dashboard/index.tsx
@@ -19,6 +19,7 @@ import LineChart from '@cloudscape-design/components/line-chart';
 import BarChart from '@cloudscape-design/components/bar-chart';
 import Spinner from '@cloudscape-design/components/spinner';
 import Alert from '@cloudscape-design/components/alert';
+import styles from './styles.module.scss';
 
 interface WeatherData {
   current: {

--- a/src/pages/weather-dashboard/index.tsx
+++ b/src/pages/weather-dashboard/index.tsx
@@ -136,7 +136,7 @@ export default function WeatherDashboard() {
     fetchWeatherData(location.latitude, location.longitude);
   }, []);
 
-  const formatTemperature = (temp: number) => `${Math.round(temp)}°C`;
+  const formatTemperature = (temp: number) => `${Math.round(temp)}°F`;
   const formatWindDirection = (degrees: number) => {
     const directions = ['N', 'NE', 'E', 'SE', 'S', 'SW', 'W', 'NW'];
     return directions[Math.round(degrees / 45) % 8];

--- a/src/pages/weather-dashboard/index.tsx
+++ b/src/pages/weather-dashboard/index.tsx
@@ -51,23 +51,23 @@ interface LocationData {
   longitude: number;
 }
 
-const weatherCodeMap: { [key: number]: { label: string; severity: 'success' | 'warning' | 'error' } } = {
-  0: { label: 'Clear sky', severity: 'success' },
-  1: { label: 'Mainly clear', severity: 'success' },
-  2: { label: 'Partly cloudy', severity: 'success' },
-  3: { label: 'Overcast', severity: 'warning' },
-  45: { label: 'Fog', severity: 'warning' },
-  48: { label: 'Depositing rime fog', severity: 'warning' },
-  51: { label: 'Light drizzle', severity: 'warning' },
-  53: { label: 'Moderate drizzle', severity: 'warning' },
-  55: { label: 'Dense drizzle', severity: 'warning' },
-  61: { label: 'Slight rain', severity: 'warning' },
-  63: { label: 'Moderate rain', severity: 'error' },
-  65: { label: 'Heavy rain', severity: 'error' },
-  71: { label: 'Slight snow', severity: 'warning' },
-  73: { label: 'Moderate snow', severity: 'error' },
-  75: { label: 'Heavy snow', severity: 'error' },
-  95: { label: 'Thunderstorm', severity: 'error' },
+const weatherCodeMap: { [key: number]: { label: string; severity: 'success' | 'warning' | 'error'; icon: string } } = {
+  0: { label: 'Clear sky', severity: 'success', icon: '☀️' },
+  1: { label: 'Mainly clear', severity: 'success', icon: '🌤️' },
+  2: { label: 'Partly cloudy', severity: 'success', icon: '⛅' },
+  3: { label: 'Overcast', severity: 'warning', icon: '☁️' },
+  45: { label: 'Fog', severity: 'warning', icon: '🌫️' },
+  48: { label: 'Depositing rime fog', severity: 'warning', icon: '🌫️' },
+  51: { label: 'Light drizzle', severity: 'warning', icon: '🌦️' },
+  53: { label: 'Moderate drizzle', severity: 'warning', icon: '🌦️' },
+  55: { label: 'Dense drizzle', severity: 'warning', icon: '🌧️' },
+  61: { label: 'Slight rain', severity: 'warning', icon: '🌧️' },
+  63: { label: 'Moderate rain', severity: 'error', icon: '🌧️' },
+  65: { label: 'Heavy rain', severity: 'error', icon: '⛈️' },
+  71: { label: 'Slight snow', severity: 'warning', icon: '❄️' },
+  73: { label: 'Moderate snow', severity: 'error', icon: '🌨️' },
+  75: { label: 'Heavy snow', severity: 'error', icon: '❄️' },
+  95: { label: 'Thunderstorm', severity: 'error', icon: '⛈️' },
 };
 
 export default function WeatherDashboard() {

--- a/src/pages/weather-dashboard/index.tsx
+++ b/src/pages/weather-dashboard/index.tsx
@@ -274,13 +274,13 @@ export default function WeatherDashboard() {
                     <LineChart
                       series={[
                         {
-                          title: 'Temperature (°C)',
+                          title: 'Temperature (°F)',
                           type: 'line',
                           data: prepareHourlyChartData(),
                         },
                       ]}
                       xDomain={[0, 23]}
-                      yTitle="Temperature (°C)"
+                      yTitle="Temperature (°F)"
                       xTitle="Hour"
                       height={300}
                       hideFilter

--- a/src/pages/weather-dashboard/index.tsx
+++ b/src/pages/weather-dashboard/index.tsx
@@ -164,9 +164,9 @@ export default function WeatherDashboard() {
   };
 
   const currentWeather = weatherData?.current;
-  const weatherCondition = currentWeather?.weather_code 
-    ? weatherCodeMap[currentWeather.weather_code] || { label: 'Unknown', severity: 'warning' as const }
-    : { label: 'Loading...', severity: 'warning' as const };
+  const weatherCondition = currentWeather?.weather_code
+    ? weatherCodeMap[currentWeather.weather_code] || { label: 'Unknown', severity: 'warning' as const, icon: '❓' }
+    : { label: 'Loading...', severity: 'warning' as const, icon: '⏳' };
 
   return (
     <AppLayout

--- a/src/pages/weather-dashboard/index.tsx
+++ b/src/pages/weather-dashboard/index.tsx
@@ -327,34 +327,39 @@ export default function WeatherDashboard() {
 
             <Container>
               <SpaceBetween size="m">
-                <Box variant="h2">Weekly Overview</Box>
+                <Box variant="h2">7-Day Forecast</Box>
                 {weatherData?.daily ? (
-                  <ColumnLayout columns={7}>
+                  <div className={styles.forecastScroll}>
                     {weatherData.daily.time.map((day, index) => {
-                      const dayWeather = weatherCodeMap[weatherData.daily.weather_code[index]] || { label: 'Unknown', severity: 'warning' as const };
+                      const dayWeather = weatherCodeMap[weatherData.daily.weather_code[index]] || {
+                        label: 'Unknown',
+                        severity: 'warning' as const,
+                        icon: '❓'
+                      };
                       return (
-                        <Box key={day} textAlign="center">
-                          <Box variant="small" fontWeight="bold">
+                        <div key={day} className={styles.forecastCard}>
+                          <div className={styles.dayName}>
                             {new Date(day).toLocaleDateString('en-US', { weekday: 'short' })}
-                          </Box>
-                          <Box margin={{ top: 'xs', bottom: 'xs' }}>
-                            <Badge color={dayWeather.severity === 'success' ? 'green' : dayWeather.severity === 'warning' ? 'blue' : 'red'}>
-                              {dayWeather.label}
-                            </Badge>
-                          </Box>
-                          <Box variant="small">
-                            <strong>{formatTemperature(weatherData.daily.temperature_2m_max[index])}</strong>
-                          </Box>
-                          <Box variant="small" color="text-status-inactive">
+                          </div>
+                          <span className={styles.weatherIcon}>
+                            {dayWeather.icon}
+                          </span>
+                          <div className={styles.conditionLabel}>
+                            {dayWeather.label}
+                          </div>
+                          <div className={styles.tempHigh}>
+                            {formatTemperature(weatherData.daily.temperature_2m_max[index])}
+                          </div>
+                          <div className={styles.tempLow}>
                             {formatTemperature(weatherData.daily.temperature_2m_min[index])}
-                          </Box>
-                          <Box variant="small">
+                          </div>
+                          <div className={styles.precipitation}>
                             {weatherData.daily.precipitation_sum[index].toFixed(1)}mm
-                          </Box>
-                        </Box>
+                          </div>
+                        </div>
                       );
                     })}
-                  </ColumnLayout>
+                  </div>
                 ) : (
                   <Box textAlign="center">
                     <Spinner />

--- a/src/pages/weather-dashboard/index.tsx
+++ b/src/pages/weather-dashboard/index.tsx
@@ -82,7 +82,7 @@ export default function WeatherDashboard() {
     setError(null);
     try {
       const response = await fetch(
-        `https://api.open-meteo.com/v1/forecast?latitude=${lat}&longitude=${lon}&current=temperature_2m,relative_humidity_2m,apparent_temperature,precipitation,wind_speed_10m,wind_direction_10m,weather_code&hourly=temperature_2m,precipitation,wind_speed_10m&daily=temperature_2m_max,temperature_2m_min,precipitation_sum,weather_code&temperature_unit=celsius&wind_speed_unit=kmh&precipitation_unit=mm&timezone=auto&forecast_days=7`
+        `https://api.open-meteo.com/v1/forecast?latitude=${lat}&longitude=${lon}&current=temperature_2m,relative_humidity_2m,apparent_temperature,precipitation,wind_speed_10m,wind_direction_10m,weather_code&hourly=temperature_2m,precipitation,wind_speed_10m&daily=temperature_2m_max,temperature_2m_min,precipitation_sum,weather_code&temperature_unit=fahrenheit&wind_speed_unit=kmh&precipitation_unit=mm&timezone=auto&forecast_days=7`
       );
       
       if (!response.ok) {

--- a/src/pages/weather-dashboard/root.tsx
+++ b/src/pages/weather-dashboard/root.tsx
@@ -1,0 +1,15 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import '@cloudscape-design/global-styles/index.css';
+import { applyMode, Mode } from '../../common/apply-mode';
+
+import App from './index';
+
+const root = createRoot(document.getElementById('app')!);
+
+applyMode(Mode.Light);
+
+root.render(<App />);

--- a/src/pages/weather-dashboard/styles.module.scss
+++ b/src/pages/weather-dashboard/styles.module.scss
@@ -1,0 +1,85 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+.forecastScroll {
+  display: flex;
+  gap: 16px;
+  overflow-x: auto;
+  padding: 16px 8px;
+  scroll-snap-type: x mandatory;
+  -webkit-overflow-scrolling: touch;
+  
+  &::-webkit-scrollbar {
+    height: 8px;
+  }
+  
+  &::-webkit-scrollbar-track {
+    background: var(--color-background-container-content);
+    border-radius: 4px;
+  }
+  
+  &::-webkit-scrollbar-thumb {
+    background: var(--color-border-control-default);
+    border-radius: 4px;
+    
+    &:hover {
+      background: var(--color-border-control-hover);
+    }
+  }
+}
+
+.forecastCard {
+  min-width: 140px;
+  flex-shrink: 0;
+  scroll-snap-align: start;
+  background: var(--color-background-container-content);
+  border: 1px solid var(--color-border-container-top);
+  border-radius: 8px;
+  padding: 16px 12px;
+  text-align: center;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  
+  &:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+  }
+}
+
+.weatherIcon {
+  font-size: 32px;
+  margin: 8px 0;
+  display: block;
+}
+
+.dayName {
+  font-weight: 600;
+  margin-bottom: 8px;
+  color: var(--color-text-body-default);
+}
+
+.tempHigh {
+  font-size: 18px;
+  font-weight: 700;
+  color: var(--color-text-body-default);
+}
+
+.tempLow {
+  font-size: 14px;
+  color: var(--color-text-status-inactive);
+  margin-bottom: 4px;
+}
+
+.precipitation {
+  font-size: 12px;
+  color: var(--color-text-status-info);
+  background: var(--color-background-status-info);
+  padding: 2px 6px;
+  border-radius: 4px;
+  display: inline-block;
+}
+
+.conditionLabel {
+  font-size: 12px;
+  color: var(--color-text-body-secondary);
+  margin-top: 4px;
+}

--- a/src/pages/weather-dashboard/styles.module.scss
+++ b/src/pages/weather-dashboard/styles.module.scss
@@ -51,6 +51,7 @@
   font-size: 32px;
   margin: 8px 0;
   display: block;
+  filter: hue-rotate(300deg) saturate(1.5);
 }
 
 .dayName {

--- a/src/pages/weather-dashboard/styles.module.scss
+++ b/src/pages/weather-dashboard/styles.module.scss
@@ -8,20 +8,20 @@
   padding: 16px 8px;
   scroll-snap-type: x mandatory;
   -webkit-overflow-scrolling: touch;
-  
+
   &::-webkit-scrollbar {
     height: 8px;
   }
-  
+
   &::-webkit-scrollbar-track {
     background: var(--color-background-container-content);
     border-radius: 4px;
   }
-  
+
   &::-webkit-scrollbar-thumb {
     background: var(--color-border-control-default);
     border-radius: 4px;
-    
+
     &:hover {
       background: var(--color-border-control-hover);
     }
@@ -37,8 +37,10 @@
   border-radius: 8px;
   padding: 16px 12px;
   text-align: center;
-  transition: transform 0.2s ease, box-shadow 0.2s ease;
-  
+  transition:
+    transform 0.2s ease,
+    box-shadow 0.2s ease;
+
   &:hover {
     transform: translateY(-2px);
     box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -30,12 +30,12 @@ export default defineConfig({
       '/api/weather': {
         target: 'https://api.open-meteo.com',
         changeOrigin: true,
-        rewrite: (path) => path.replace(/^\/api\/weather/, ''),
+        rewrite: path => path.replace(/^\/api\/weather/, ''),
       },
       '/api/geocoding': {
         target: 'https://geocoding-api.open-meteo.com',
         changeOrigin: true,
-        rewrite: (path) => path.replace(/^\/api\/geocoding/, ''),
+        rewrite: path => path.replace(/^\/api\/geocoding/, ''),
       },
     },
   },

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -26,5 +26,17 @@ export default defineConfig({
   },
   server: {
     port: 5173,
+    proxy: {
+      '/api/weather': {
+        target: 'https://api.open-meteo.com',
+        changeOrigin: true,
+        rewrite: (path) => path.replace(/^\/api\/weather/, ''),
+      },
+      '/api/geocoding': {
+        target: 'https://geocoding-api.open-meteo.com',
+        changeOrigin: true,
+        rewrite: (path) => path.replace(/^\/api\/geocoding/, ''),
+      },
+    },
   },
 });


### PR DESCRIPTION
## Purpose

Based on user feedback, this PR implements a weather dashboard with temperature display in Fahrenheit instead of Celsius, and features a horizontally scrollable 7-day forecast with weather icons/emojis to represent different weather conditions like cloudy, sunny, and rainy weather.

## Code changes

- **New weather dashboard page**: Created `/weather-dashboard` route with complete weather interface
- **Temperature units**: Configured API calls to use Fahrenheit (`temperature_unit=fahrenheit`) 
- **Scrollable forecast**: Implemented horizontal scroll container for 7-day forecast with CSS scroll styling
- **Weather icons**: Added emoji-based weather condition indicators (☀️, ⛅, 🌧️, ❄️, ⛈️, etc.)
- **API integration**: Set up proxy configuration for Open-Meteo weather and geocoding APIs
- **Responsive design**: Created forecast cards with hover effects and proper spacing
- **Demo integration**: Added weather dashboard to main demos list under "Dashboards" category

The dashboard includes current weather conditions, 24-hour temperature trends, and the requested scrollable 7-day forecast with visual weather representations.

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 3`

🔗 [Edit in Builder.io](https://builder.io/app/projects/669aea15bfb94f68a517fc7342d55463/curry-studio)

👀 [Preview Link](https://669aea15bfb94f68a517fc7342d55463-curry-studio.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>669aea15bfb94f68a517fc7342d55463</projectId>-->
<!--<branchName>curry-studio</branchName>-->